### PR TITLE
Fixing #1 issue: [BUG] BIKEL5 doesn't appear as an option in the application's functionality

### DIFF
--- a/api/src/enums/algorithms.py
+++ b/api/src/enums/algorithms.py
@@ -3,6 +3,7 @@ from enum import Enum
 class QuantumSafeAlgorithms(Enum):
     BIKEL1 = 'bikel1'
     BIKEL3 = 'bikel3'
+    BIKEL5 = 'bikel5'
     KYBER512 = 'kyber512'
     KYBER768 = 'kyber768'
     KYBER1024 = 'kyber1024'


### PR DESCRIPTION
### Description

Adds BIKEL5 declaration to algorithms.py file in [qujata/api/src/enums/](https://github.com/atisorg/qujata/blob/ffe4f54c1713cc8f7c1b76be7d7d69c20f730d77/api/src/enums/algorithms.py), fixing BIKEL5 algorithm not showing up in the application's functionality.

### What I did

Include BIKEL5 declaration in the algorithms.py file.

### Related issues

Closes #1