### PR TITLE
Fixing #3 issue: [BUG] Nginx docker build fails as NodeJS versions greater than 14 need a WORKDIR specification

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,8 @@
 FROM openquantumsafe/nginx:latest
 
+# NodeJS version > 14 requires not being in root directory while npm install
+WORKDIR /usr/app
+
 ADD nginx.conf /opt/nginx/nginx-conf/nginx.conf
 ADD app.js app.js
 ADD start.sh start.sh


### PR DESCRIPTION
### Description

Adds a WORKDIR specification to the Nginx Dockerfile available at [qujata/nginx](https://github.com/atisorg/qujata/tree/ffe4f54c1713cc8f7c1b76be7d7d69c20f730d77/nginx), fixing Docker build error related to NodeJS version.

### What I did

Include a WORKDIR specification in the Nginx Dockerfile.

### Related issues

Closes #3 